### PR TITLE
Add a root index so the site has a front door

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,60 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Quantum Logical Framework</title>
+<meta name="description" content="A constructive foundation for mathematics and physics built from a single finite distinction — one Zero-Free-Action event.">
+<style>
+  :root { --fg:#1a1a1a; --dim:#5a5a5a; --line:#e3e3e3; --link:#0a6b4f; --bg:#fff; }
+  @media (prefers-color-scheme: dark) {
+    :root { --fg:#e8e8e8; --dim:#a0a0a0; --line:#2c2c2c; --link:#5fd0a8; --bg:#141414; }
+  }
+  * { box-sizing: border-box; }
+  body { margin:0; background:var(--bg); color:var(--fg);
+         font:16px/1.65 system-ui,-apple-system,"Segoe UI",sans-serif; }
+  main { max-width:44rem; margin:0 auto; padding:12vh 1.5rem 6rem; }
+  h1 { font-size:1.9rem; line-height:1.2; margin:0 0 .4rem; letter-spacing:-.01em; }
+  .tagline { color:var(--dim); margin:0 0 2.5rem; }
+  .tagline b { color:var(--fg); font-weight:600; }
+  h2 { font-size:.78rem; text-transform:uppercase; letter-spacing:.09em;
+       color:var(--dim); font-weight:600; margin:0 0 1rem; }
+  ul { list-style:none; padding:0; margin:0 0 3rem; }
+  li { border-top:1px solid var(--line); }
+  li:last-child { border-bottom:1px solid var(--line); }
+  a.card { display:block; padding:1.1rem .25rem; color:inherit; text-decoration:none; }
+  a.card:hover, a.card:focus { background:color-mix(in srgb, var(--link) 7%, transparent); }
+  .name { color:var(--link); font-weight:600; }
+  .what { color:var(--dim); font-size:.93rem; margin-top:.15rem; }
+  .more { color:var(--dim); font-size:.93rem; }
+  .more a { color:var(--link); }
+</style>
+</head>
+<body>
+<main>
+  <h1>Quantum Logical Framework</h1>
+  <p class="tagline"><b>The universe is logical. Spacetime is synthesized.</b><br>
+     Physical reality is the subset of possibility that achieves Zero Free Action.</p>
+
+  <h2>Interactive</h2>
+  <ul>
+    <li><a class="card" href="FlowChart.html">
+      <span class="name">Flow Chart</span>
+      <div class="what">A visual map of the framework — how the pieces derive from one another.</div>
+    </a></li>
+    <li><a class="card" href="spacetime_constructor.html">
+      <span class="name">Spectral Spacetime</span>
+      <div class="what">The frequency constructor. Heat toward the Planck top and watch spacetime synthesize.</div>
+    </a></li>
+    <li><a class="card" href="fredkin_machine.html">
+      <span class="name">The Fredkin Machine</span>
+      <div class="what">Conservative logic on the QLF substrate — the ball count holds, reversibly.</div>
+    </a></li>
+  </ul>
+
+  <p class="more">The framework itself is written up across the repository:
+     <a href="https://github.com/rchain-community/quantum-logical-framework#readme">start with the README</a>,
+     or browse the <a href="https://github.com/rchain-community/quantum-logical-framework">source and Lean proofs</a>.</p>
+</main>
+</body>
+</html>


### PR DESCRIPTION
`https://rchain-community.github.io/quantum-logical-framework/` returns 404 while every deep link works — `spacetime_constructor.html`, `FlowChart.html` and `fredkin_machine.html` all serve fine.

## Why

The Pages workflow rsyncs the repo into `_site` and touches `.nojekyll`. That serves every `.html` at the root as-is, but it also means Jekyll never renders `README.md` into an `index.html` — and the repo doesn't have one. So nothing answers `/`.

**This is not fallout from the org transfer**, which is what it looked like at first. The root has simply never had an index; nothing links to it, so it went unnoticed.

## This PR

An `index.html` linking the three interactive pages, each with a line on what it does, plus a pointer to the README for the framework itself. Titles and descriptions are taken from the pages themselves rather than invented. Dark mode follows the reader's system setting; no external assets, no build step.

Deliberately kept as a front door rather than a summary of QLF — the README is the write-up, and duplicating it here would create a second thing to keep current.

🤖 Generated with [Claude Code](https://claude.com/claude-code)